### PR TITLE
[OOB] Upgrades 'php' to '1.5.0'

### DIFF
--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.1",
+  "version": "1.5.0",
   "imageNameSuffix": "php",
   "dockerFile": "src/php/Dockerfile",
   "context": "."


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `php`
Version: `1.4.1` -> `1.5.0`