### PR TITLE
[OOB] Upgrades 'dotnet-core' to '2.1.21'

### DIFF
--- a/src/dotnet-core/manifest.json
+++ b/src/dotnet-core/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.20",
+  "version": "2.1.21",
   "imageNameSuffix": "dotnet-core",
   "dockerFile": "src/dotnet-core/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet-core`
Version: `2.1.20` -> `2.1.21`