### PR TITLE
[OOB] Upgrades 'java' to '4.2.0'

### DIFF
--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0",
+  "version": "4.2.0",
   "imageNameSuffix": "java",
   "dockerFile": "src/java/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `java`
Version: `4.1.0` -> `4.2.0`