### PR TITLE
[OOB] Upgrades 'nodejs-protect' to '5.1.0'

### DIFF
--- a/src/nodejs-protect/manifest.json
+++ b/src/nodejs-protect/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.1",
+  "version": "5.1.0",
   "imageNameSuffix": "nodejs-protect",
   "dockerFile": "src/nodejs-protect/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `nodejs-protect`
Version: `5.0.1` -> `5.1.0`