### PR TITLE
[OOB] Upgrades 'dotnet-framework' to '50.1.11'

### DIFF
--- a/src/dotnet-framework/manifest.json
+++ b/src/dotnet-framework/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "50.1.10",
+  "version": "50.1.11",
   "imageNameSuffix": "dotnet-framework",
   "dockerFile": "src/dotnet-framework/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet-framework`
Version: `50.1.10` -> `50.1.11`