### PR TITLE
[OOB] Upgrades 'nodejs-protect' to '5.4.1'

### DIFF
--- a/src/nodejs-protect/manifest.json
+++ b/src/nodejs-protect/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.4.0",
+  "version": "5.4.1",
   "imageNameSuffix": "nodejs-protect",
   "dockerFile": "src/nodejs-protect/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `nodejs-protect`
Version: `5.4.0` -> `5.4.1`