### PR TITLE
[OOB] Upgrades 'nodejs' to '4.32.0'

### DIFF
--- a/src/nodejs/manifest.json
+++ b/src/nodejs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.31.2",
+  "version": "4.32.0",
   "imageNameSuffix": "nodejs",
   "dockerFile": "src/nodejs/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `nodejs`
Version: `4.31.2` -> `4.32.0`