### PR TITLE
[OOB] Upgrades 'dotnet-core' to '4.0.0'

### DIFF
--- a/src/dotnet-core/manifest.json
+++ b/src/dotnet-core/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.3",
+  "version": "4.0.0",
   "imageNameSuffix": "dotnet-core",
   "dockerFile": "src/dotnet-core/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet-core`
Version: `3.0.3` -> `4.0.0`