### PR TITLE
DOTNET-5162 Publish arm64 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,13 @@ jobs:
           "image-name=ghcr.io/contrast-security-oss/agent-operator-images/agent-$($manifest.imageNameSuffix)" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
-      - uses: docker/setup-buildx-action@v2
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v2
         with:
           install: true
           version: latest

--- a/.github/workflows/oob-update.yaml
+++ b/.github/workflows/oob-update.yaml
@@ -74,10 +74,8 @@ jobs:
             oob-update
           token: ${{ secrets.GH_PR_WRITE_PAT }}
 
-      - uses: peter-evans/enable-pull-request-automerge@v2
+      - name: Enable Pull Request Automerge
         if: steps.create-pr.outputs.pull-request-operation == 'created'
-        with:
-          # Uses the dispatch service user, using the dotnet PAT.
-          token: ${{ secrets.GH_PR_WRITE_PAT }}
-          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
-          merge-method: rebase
+        run: gh pr merge --rebase --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PR_WRITE_PAT }}

--- a/src/dotnet-core/manifest.json
+++ b/src/dotnet-core/manifest.json
@@ -3,13 +3,15 @@
   "imageNameSuffix": "dotnet-core",
   "dockerFile": "src/dotnet-core/Dockerfile",
   "context": ".",
-  "platforms": "linux/amd64",
+  "platforms": "linux/amd64,linux/arm64",
   "validation": {
     "enabled": true,
     "expects": [
       "image-manifest.json",
       "runtimes/linux-x64/native/ContrastProfiler.so",
-      "runtimes/linux-x64/native/ContrastChainLoader.so"
+      "runtimes/linux-x64/native/ContrastChainLoader.so",
+      "runtimes/linux-arm64/native/ContrastProfiler.so",
+      "runtimes/linux-arm64/native/ContrastChainLoader.so"
     ]
   }
 }

--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -3,6 +3,7 @@
   "imageNameSuffix": "java",
   "dockerFile": "src/java/Dockerfile",
   "context": ".",
+  "platforms": "linux/amd64,linux/arm64",
   "validation": {
     "enabled": true,
     "expects": [

--- a/src/nodejs-protect/manifest.json
+++ b/src/nodejs-protect/manifest.json
@@ -3,7 +3,7 @@
   "imageNameSuffix": "nodejs-protect",
   "dockerFile": "src/nodejs-protect/Dockerfile",
   "context": ".",
-  "platforms": "linux/amd64",
+  "platforms": "linux/amd64,linux/arm64",
   "validation": {
     "enabled": true,
     "expects": [

--- a/src/nodejs/manifest.json
+++ b/src/nodejs/manifest.json
@@ -3,7 +3,7 @@
   "imageNameSuffix": "nodejs",
   "dockerFile": "src/nodejs/Dockerfile",
   "context": ".",
-  "platforms": "linux/amd64",
+  "platforms": "linux/amd64,linux/arm64",
   "validation": {
     "enabled": true,
     "expects": [


### PR DESCRIPTION
* Publish arm64 images for java, dotnet-core, nodejs, nodejs-protect
* Replace deprecated github action for automerge with github cli