### PR TITLE
[OOB] Upgrades 'java' to '5.3.0'

### DIFF
--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.3",
+  "version": "5.3.0",
   "imageNameSuffix": "java",
   "dockerFile": "src/java/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `java`
Version: `5.2.3` -> `5.3.0`