### PR TITLE
[OOB] Upgrades 'php' to '1.23.0'

### DIFF
--- a/src/php/manifest.json
+++ b/src/php/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.22.0",
+  "version": "1.23.0",
   "imageNameSuffix": "php",
   "dockerFile": "src/php/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `php`
Version: `1.22.0` -> `1.23.0`