### PR TITLE
DOTNET-5305 Add python init container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 /src/java/ @Contrast-Security-OSS/java-team
 /src/php/ @Contrast-Security-OSS/php-agent-team
 /src/nodejs/ @Contrast-Security-OSS/node-team
+/src/python/ @Contrast-Security-OSS/python-team

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           - java
           - nodejs
           - php
+          - python
     runs-on: ubuntu-latest
     outputs:
       artifact-image-dotnet-core: ${{ steps.detect-artifact.outputs.artifact-image-dotnet-core }}
@@ -30,6 +31,8 @@ jobs:
       artifact-version-nodejs: ${{ steps.detect-artifact.outputs.artifact-version-nodejs }}
       artifact-image-php: ${{ steps.detect-artifact.outputs.artifact-image-php }}
       artifact-version-php: ${{ steps.detect-artifact.outputs.artifact-version-php }}
+      artifact-image-python: ${{ steps.detect-artifact.outputs.artifact-image-python }}
+      artifact-version-python: ${{ steps.detect-artifact.outputs.artifact-version-python }}
     env:
       AGENT_TYPE: ${{ matrix.variant }}
     steps:
@@ -124,6 +127,9 @@ jobs:
         - type: php
           digest: ${{ needs.build.outputs.artifact-image-php }}
           version: ${{ needs.build.outputs.artifact-version-php }}
+        - type: python
+          digest: ${{ needs.build.outputs.artifact-image-python }}
+          version: ${{ needs.build.outputs.artifact-version-python }}
     if: ${{ !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]') }}
     steps:
       - uses: actions/checkout@v4
@@ -163,6 +169,7 @@ jobs:
             java: ${{ needs.build.outputs.artifact-image-java }}
             nodejs: ${{ needs.build.outputs.artifact-image-nodejs }}
             php: ${{ needs.build.outputs.artifact-image-php }}
+            python: ${{ needs.build.outputs.artifact-image-python }}
             ```
   #
   # Release Internal Stage
@@ -191,6 +198,9 @@ jobs:
         - type: php
           digest: ${{ needs.build.outputs.artifact-image-php }}
           version: ${{ needs.build.outputs.artifact-version-php }}
+        - type: python
+          digest: ${{ needs.build.outputs.artifact-image-python }}
+          version: ${{ needs.build.outputs.artifact-version-python }}
     concurrency:
       group: internal-${{ matrix.variants.type }}
     if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/backport/') }}
@@ -246,6 +256,9 @@ jobs:
         - type: php
           digest: ${{ needs.build.outputs.artifact-image-php }}
           version: ${{ needs.build.outputs.artifact-version-php }}
+        - type: python
+          digest: ${{ needs.build.outputs.artifact-image-python }}
+          version: ${{ needs.build.outputs.artifact-version-python }}
     concurrency:
       group: public-${{ matrix.variants.type }}
     if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/backport/') }}

--- a/.github/workflows/oob-update.yaml
+++ b/.github/workflows/oob-update.yaml
@@ -20,7 +20,7 @@ jobs:
           [string] $agentVersion = $clientPayload.version
           [string] $manifestPath = "./src/$agentType/manifest.json"
 
-          if ($agentType -notmatch '^(nodejs|java|dotnet-core|dotnet-framework|php)$')
+          if ($agentType -notmatch '^(nodejs|java|dotnet-core|dotnet-framework|php|python)$')
           {
               Write-Error "Failed to validate agent type."
               exit 1

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Public images are deployed to DockerHub. Currently, this repo publishes:
 - [![contrast/agent-java](https://img.shields.io/docker/v/contrast/agent-java?label=contrast%2Fagent-java&logo=docker&logoColor=white&style=flat-square&cacheSeconds=10800)](https://hub.docker.com/r/contrast/agent-java)
 - [![contrast/agent-nodejs](https://img.shields.io/docker/v/contrast/agent-nodejs?label=contrast%2Fagent-nodejs&logo=docker&logoColor=white&style=flat-square&cacheSeconds=10800)](https://hub.docker.com/r/contrast/agent-nodejs)
 - [![contrast/agent-php](https://img.shields.io/docker/v/contrast/agent-php?label=contrast%2Fagent-php&logo=docker&logoColor=white&style=flat-square&cacheSeconds=10800)](https://hub.docker.com/r/contrast/agent-php)
+- - [![contrast/agent-python](https://img.shields.io/docker/v/contrast/agent-python?label=contrast%2Fagent-python&logo=docker&logoColor=white&style=flat-square&cacheSeconds=10800)](https://hub.docker.com/r/contrast/agent-python)
 
 
 Tags are generated in the following format:

--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -1,0 +1,95 @@
+# Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+FROM python:3.12-slim-bullseye AS builder-312
+
+ARG VERSION=7.2.0
+
+RUN set -xe \
+  && apt-get update \
+  && apt-get install -y build-essential autoconf
+
+RUN set -xe \
+  && mkdir -p /contrast \
+  && echo ${VERSION} \
+  && pip install --target=/contrast "contrast-agent==${VERSION}" \
+  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
+
+FROM python:3.11-slim-bullseye AS builder-311
+
+ARG VERSION=7.2.0
+
+RUN set -xe \
+  && apt-get update \
+  && apt-get install -y build-essential autoconf
+
+RUN set -xe \
+  && mkdir -p /contrast \
+  && echo ${VERSION} \
+  && pip install --target=/contrast "contrast-agent==${VERSION}" \
+  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
+
+FROM python:3.10-slim-bullseye AS builder-310
+
+ARG VERSION=7.2.0
+
+RUN set -xe \
+  && apt-get update \
+  && apt-get install -y build-essential autoconf
+
+RUN set -xe \
+  && mkdir -p /contrast \
+  && echo ${VERSION} \
+  && pip install --target=/contrast "contrast-agent==${VERSION}" \
+  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
+
+FROM python:3.9-slim-bullseye AS builder-39
+
+ARG VERSION=7.2.0
+
+RUN set -xe \
+  && apt-get update \
+  && apt-get install -y build-essential autoconf
+
+RUN set -xe \
+  && mkdir -p /contrast \
+  && echo ${VERSION} \
+  && pip install --target=/contrast "contrast-agent==${VERSION}" \
+  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
+
+FROM python:3.8-slim-bullseye AS builder-38
+
+ARG VERSION=7.2.0
+
+RUN set -xe \
+  && apt-get update \
+  && apt-get install -y build-essential autoconf
+
+RUN set -xe \
+  && mkdir -p /contrast \
+  && echo ${VERSION} \
+  && pip install --target=/contrast "contrast-agent==${VERSION}" \
+  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
+
+
+FROM busybox:stable AS final
+
+RUN set -xe \
+  && addgroup -g 1001 custom-group \
+  && adduser -u 1001 -G custom-group -D -H custom-user
+
+COPY ./src/shared/entrypoint.sh /entrypoint.sh
+COPY --from=builder-312 /contrast /contrast
+COPY --from=builder-311 /contrast /contrast
+COPY --from=builder-310 /contrast /contrast
+COPY --from=builder-39 /contrast /contrast
+COPY --from=builder-38 /contrast /contrast
+
+ARG VERSION=7.2.0
+ENV CONTRAST_MOUNT_PATH=/contrast-init \
+  CONTRAST_VERSION=${VERSION} \
+  CONTRAST_AGENT_TYPE=python
+
+USER 1001
+
+ENTRYPOINT [ "/bin/sh", "/entrypoint.sh" ]

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,0 +1,13 @@
+{
+  "version": "7.2.0",
+  "imageNameSuffix": "python",
+  "dockerFile": "src/python/Dockerfile",
+  "context": ".",
+  "platforms": "linux/amd64",
+  "validation": {
+    "enabled": true,
+    "expects": [
+      "contrast/loader/__init__.py"
+    ]
+  }
+}

--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -7,7 +7,8 @@
   "validation": {
     "enabled": true,
     "expects": [
-      "contrast/loader/__init__.py"
+      "contrast/loader/__init__.py",
+      "image-manifest.json"
     ]
   }
 }


### PR DESCRIPTION
Working for python versions 3.8-3.12 but we can't support alpine due to filename collisions with one of the c extensions.

Python wheels would have made this easier (instead we make a builder for each python version and merge all of them together)