### PR TITLE
[OOB] Upgrades 'java' to '6.2.1'

### DIFF
--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2.0",
+  "version": "6.2.1",
   "imageNameSuffix": "java",
   "dockerFile": "src/java/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `java`
Version: `6.2.0` -> `6.2.1`