### PR TITLE
manually upgrade python version to 7.4.0

### DIFF
--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.3.0",
+  "version": "7.4.0",
   "imageNameSuffix": "python",
   "dockerFile": "src/python/Dockerfile",
   "context": ".",


### PR DESCRIPTION
A pipeline issue prevented the automated upgrade.

It should be fixed in https://github.com/Contrast-Security-Inc/python-agent/pull/1952

We've also made https://github.com/Contrast-Security-Inc/python-agent/pull/1953 to reduce the dependencies of this operator update step, which should make future failures less likely.