### PR TITLE
[OOB] Upgrades 'java' to '6.3.2'

### DIFF
--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.3.1",
+  "version": "6.3.2",
   "imageNameSuffix": "java",
   "dockerFile": "src/java/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `java`
Version: `6.3.1` -> `6.3.2`