### PR TITLE
Pin node version

### DIFF
--- a/src/nodejs/Dockerfile
+++ b/src/nodejs/Dockerfile
@@ -1,7 +1,7 @@
 # Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-FROM node:lts-bookworm-slim AS builder
+FROM node:20.11.1-alpine AS builder
 
 ARG VERSION=4.18.0
 


### PR DESCRIPTION
SWC library has changed and only installs the native components for the OS it was installed on (so we are missing alpine bits because we install on bookworm). Pinning to this version (and alpine) is a workaround for now. 