### PR TITLE
[OOB] Upgrades 'dotnet-framework' to '51.0.28'

### DIFF
--- a/src/dotnet-framework/manifest.json
+++ b/src/dotnet-framework/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "51.0.26",
+  "version": "51.0.28",
   "imageNameSuffix": "dotnet-framework",
   "dockerFile": "src/dotnet-framework/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet-framework`
Version: `51.0.26` -> `51.0.28`