### PR TITLE
[OOB] Upgrades 'python' to '8.1.0'

### DIFF
--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.0.0",
+  "version": "8.1.0",
   "imageNameSuffix": "python",
   "dockerFile": "src/python/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `python`
Version: `8.0.0` -> `8.1.0`