### PR TITLE
[OOB] Upgrades 'nodejs' to '5.7.0'

### DIFF
--- a/src/nodejs/manifest.json
+++ b/src/nodejs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.6.2",
+  "version": "5.7.0",
   "imageNameSuffix": "nodejs",
   "dockerFile": "src/nodejs/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `nodejs`
Version: `5.6.2` -> `5.7.0`