### PR TITLE
[OOB] Upgrades 'python' to '9.4.0'

### DIFF
--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "9.3.0",
+  "version": "9.4.0",
   "imageNameSuffix": "python",
   "dockerFile": "src/python/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `python`
Version: `9.3.0` -> `9.4.0`