### PR TITLE
[OOB] Upgrades 'java' to '6.12.0'

### DIFF
--- a/src/java/manifest.json
+++ b/src/java/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.11.1",
+  "version": "6.12.0",
   "imageNameSuffix": "java",
   "dockerFile": "src/java/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `java`
Version: `6.11.1` -> `6.12.0`