### PR TITLE
[OOB] Upgrades 'python' to '10.0.2'

### DIFF
--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.0.0",
+  "version": "10.0.2",
   "imageNameSuffix": "python",
   "dockerFile": "src/python/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `python`
Version: `10.0.0` -> `10.0.2`