### PR TITLE
PYT-3173: download wheels for the Python agent

### DIFF
--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -1,59 +1,16 @@
 # Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-FROM python:3.13-slim-bookworm AS builder-313
-ARG VERSION=9.8.0
+FROM python:3.9-slim-bookworm AS builder
+ARG VERSION=10.0.2
 RUN set -xe \
   && apt-get update \
-  && apt-get install -y build-essential autoconf
+  && apt-get install unzip
+COPY ./src/python/fetch-python.sh .
 RUN set -xe \
   && mkdir -p /contrast \
   && echo ${VERSION} \
-  && pip install --target=/contrast "contrast-agent==${VERSION}" \
-  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
-
-FROM python:3.12-slim-bookworm AS builder-312
-ARG VERSION=9.8.0
-RUN set -xe \
-  && apt-get update \
-  && apt-get install -y build-essential autoconf
-RUN set -xe \
-  && mkdir -p /contrast \
-  && echo ${VERSION} \
-  && pip install --target=/contrast "contrast-agent==${VERSION}" \
-  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
-
-FROM python:3.11-slim-bookworm AS builder-311
-ARG VERSION=9.8.0
-RUN set -xe \
-  && apt-get update \
-  && apt-get install -y build-essential autoconf
-RUN set -xe \
-  && mkdir -p /contrast \
-  && echo ${VERSION} \
-  && pip install --target=/contrast "contrast-agent==${VERSION}" \
-  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
-
-FROM python:3.10-slim-bookworm AS builder-310
-ARG VERSION=9.8.0
-RUN set -xe \
-  && apt-get update \
-  && apt-get install -y build-essential autoconf
-RUN set -xe \
-  && mkdir -p /contrast \
-  && echo ${VERSION} \
-  && pip install --target=/contrast "contrast-agent==${VERSION}" \
-  && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
-
-FROM python:3.9-slim-bookworm AS builder-39
-ARG VERSION=9.8.0
-RUN set -xe \
-  && apt-get update \
-  && apt-get install -y build-essential autoconf
-RUN set -xe \
-  && mkdir -p /contrast \
-  && echo ${VERSION} \
-  && pip install --target=/contrast "contrast-agent==${VERSION}" \
+  && ./fetch-python.sh ${VERSION} /contrast \
   && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
 
 
@@ -64,13 +21,9 @@ RUN set -xe \
   && adduser -u 1001 -G custom-group -D -H custom-user
 
 COPY ./src/shared/entrypoint.sh /entrypoint.sh
-COPY --from=builder-313 /contrast /contrast
-COPY --from=builder-312 /contrast /contrast
-COPY --from=builder-311 /contrast /contrast
-COPY --from=builder-310 /contrast /contrast
-COPY --from=builder-39 /contrast /contrast
+COPY --from=builder /contrast /contrast
 
-ARG VERSION=9.8.0
+ARG VERSION=10.0.2
 ENV CONTRAST_MOUNT_PATH=/contrast-init \
   CONTRAST_VERSION=${VERSION} \
   CONTRAST_AGENT_TYPE=python

--- a/src/python/fetch-python.sh
+++ b/src/python/fetch-python.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+if [ "${1-}" == "--help" ] || [ "${1-}" == "-h" ]; then
+    echo "Usage: $0 [version] [destination]"
+    echo "  [version]      : Optional. The version of the contrast-agent to download (e.g., 'latest' or '1.2.3'). Defaults to latest."
+    echo "  [destination]  : Optional. The directory to save the downloaded files. Defaults to /agents/python/{version}/."
+    exit 1
+fi
+
+VERSION=${1:-"latest"}
+if [ "$VERSION" == "latest" ]; then
+    VERSION=$(
+        python3 -m pip index versions "contrast-agent" --only-binary :all: \
+        | sed -n 's/.*contrast-agent (\(.*\)).*/\1/p'
+    )
+fi
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+REPO_ROOT="$SCRIPT_DIR/../.."
+DESTINATION=${2:-"$REPO_ROOT/agents/python/$VERSION/"}
+
+PLATFORMS="manylinux_2_17_x86_64 musllinux_1_2_x86_64"
+PYTHON_VERSIONS="39 310 311 312 313"
+
+TEMP_DIR=$(mktemp -d)
+
+for platform in $PLATFORMS; do
+    for py_version in $PYTHON_VERSIONS; do
+        echo "Downloading wheels for $platform $py_version";
+        python3 -m pip download \
+        --dest "$TEMP_DIR" \
+        --only-binary :all: \
+        --platform "$platform" \
+        --python-version "$py_version" \
+        "contrast-agent==$VERSION";
+    done
+done
+
+mkdir -p "$DESTINATION"
+for file in "$TEMP_DIR"/*.whl; do
+    unzip -o "$file" -d "$DESTINATION";
+done
+rm -rf "$TEMP_DIR"
+
+echo "Download complete"


### PR DESCRIPTION
The Python agent has started distributing prebuilt wheels in v10.0.0 . This change updates the build to use those wheels. Some advantages of wheels include
  * no longer needing a separate build stage for each supported Python version
  * easier reproducibility, since we're downloading prebuilt packages instead of building them in a slim-bookworm image.
  * now supporting Alpine and other musllibc environments! (with libgcc available at runtime for linking)

This script may appear overly complex. It's generalized so that it can be used by other Contrast installation tools with minimal changes.