### PR TITLE
[OOB] Upgrades 'dotnet-core' to '4.3.9'

### DIFF
--- a/src/dotnet-core/Dockerfile
+++ b/src/dotnet-core/Dockerfile
@@ -1,7 +1,7 @@
 # Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-FROM ubuntu:jammy AS builder
+FROM --platform=$BUILDPLATFORM ubuntu:jammy AS builder
 
 RUN set -xe \
   && apt-get update \

--- a/src/dotnet-core/manifest.json
+++ b/src/dotnet-core/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.3.8",
+  "version": "4.3.9",
   "imageNameSuffix": "dotnet-core",
   "dockerFile": "src/dotnet-core/Dockerfile",
   "context": ".",

--- a/src/dotnet-framework/Dockerfile
+++ b/src/dotnet-framework/Dockerfile
@@ -1,7 +1,7 @@
 # Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-FROM --platform=$BUILDPLATFORM ubuntu:jammy AS builder
+FROM --platform=$BUILDPLATFORM ubuntu:noble AS builder
 
 RUN set -xe \
   && apt-get update \

--- a/src/java/Dockerfile
+++ b/src/java/Dockerfile
@@ -1,7 +1,7 @@
 # Contrast Security, Inc licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-FROM ubuntu:jammy AS builder
+FROM --platform=$BUILDPLATFORM ubuntu:noble AS builder
 
 RUN set -xe \
   && apt-get update \


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet-core`
Version: `4.3.8` -> `4.3.9`