### PR TITLE
bugfix: skip musl download for python 3.9 and 3.10

### DIFF
--- a/src/python/fetch-python.sh
+++ b/src/python/fetch-python.sh
@@ -30,6 +30,14 @@ TEMP_DIR=$(mktemp -d)
 
 for platform in $PLATFORMS; do
     for py_version in $PYTHON_VERSIONS; do
+        if [[ "$platform" == "musl"* && ("$py_version" == "39" || "$py_version" == "310") ]]; then
+            # In python 3.10 and earlier, musl builds and glibc C extension builds have
+            # the same filename. This causes some binaries to be overwritten when
+            # combined into a single directory.
+            # See https://github.com/python/cpython/issues/87278
+            echo "Skipping download for $platform $py_version";
+            continue
+        fi
         echo "Downloading wheels for $platform $py_version";
         python3 -m pip download \
         --dest "$TEMP_DIR" \


### PR DESCRIPTION
There's an issue with python in the operator currently. Description approximately copied from [slack](https://contrastsecurityinc.slack.com/archives/CFD8WK17X/p1741040741907349?thread_ts=1741012578.142949&cid=CFD8WK17X):

---

For python, the operator comes bundled with every possible binary we might need at runtime (all supported python versions + platforms). The problem is that in python 3.10 and earlier, C extension .so files built for musl and glibc have the same filename (this was identified as a [bug in cpython](https://github.com/python/cpython/issues/87278)). When we added musl support to the operator we started accidentally overwriting the glibc builds for 3.9 and 3.10 with musl builds.

We're going to be able to fix the build so that the operator works again for all supported python versions on non-alpine linux. However, alpine support for the operator will be limited to python 3.11+.

---

Basically, the "fat wheel" we bundle into the operator won't work for both glibc and musl in python 3.9 and 3.10 due to binary name conflicts. This PR skips downloading musl since we expect glibc to be more useful / likely.

It seems like this will affect the universal agent as well. @contrast-jproberts is going to port this change to that project.