### PR TITLE
AO-68 Copy the ContrastChainLoader based on arch 

### DIFF
--- a/src/dotnet-core/Dockerfile
+++ b/src/dotnet-core/Dockerfile
@@ -17,12 +17,29 @@ RUN set -xe \
   && chmod +x /contrast/diagnostics/linux-arm64/contrast-dotnet-diagnostics \
   && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
 
-FROM --platform=linux busybox:stable AS final-linux
+FROM --platform=linux/amd64 busybox:stable AS final-linux-amd64
 RUN set -xe \
   && addgroup -g 1001 custom-group \
   && adduser -u 1001 -G custom-group -D -H custom-user
 COPY ./src/shared/entrypoint.sh /entrypoint.sh
 COPY --from=builder /contrast /contrast
+RUN mkdir -p /contrast/runtimes/linux/native \
+    && cp /contrast/runtimes/linux-x64/native/ContrastChainLoader.so /contrast/runtimes/linux/native
+ARG VERSION=4.2.8
+ENV CONTRAST_MOUNT_PATH=/contrast-init \
+  CONTRAST_VERSION=${VERSION} \
+  CONTRAST_AGENT_TYPE=dotnet-core
+USER 1001
+ENTRYPOINT [ "/bin/sh", "/entrypoint.sh" ]
+
+FROM --platform=linux/arm64 busybox:stable AS final-linux-arm64
+RUN set -xe \
+  && addgroup -g 1001 custom-group \
+  && adduser -u 1001 -G custom-group -D -H custom-user
+COPY ./src/shared/entrypoint.sh /entrypoint.sh
+COPY --from=builder /contrast /contrast
+RUN mkdir -p /contrast/runtimes/linux/native \
+    && cp /contrast/runtimes/linux-arm64/native/ContrastChainLoader.so /contrast/runtimes/linux/native
 ARG VERSION=4.2.8
 ENV CONTRAST_MOUNT_PATH=/contrast-init \
   CONTRAST_VERSION=${VERSION} \
@@ -32,8 +49,8 @@ ENTRYPOINT [ "/bin/sh", "/entrypoint.sh" ]
 
 # We don't currently support Windows containers in the Agent Operator
 # This image exists purely get .NET Core agent files into windows container images.
-FROM --platform=windows/amd64 mcr.microsoft.com/windows/nanoserver:2004 AS final-windows
+FROM --platform=windows/amd64 mcr.microsoft.com/windows/nanoserver:2004 AS final-windows-amd64
 COPY --from=builder /contrast /contrast
 
-# Use the correct final image based on targetos
-FROM final-$TARGETOS
+# Use the correct final image based on TARGETPLATFORM
+FROM final-$TARGETOS-$TARGETARCH


### PR DESCRIPTION
Copy the ContrastChainLoader based on arch  to the /runtimes/linux/native folder

This is blocked until the next release of the dotnet-agent with a fix for the ContrastChainLoader looking for the correct ContrastProfiler.so