### PR TITLE
python: use json output to get latest version

### DIFF
--- a/src/python/Dockerfile
+++ b/src/python/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.9-slim-bookworm AS builder
 ARG VERSION=10.0.2
 RUN set -xe \
   && apt-get update \
-  && apt-get install unzip
+  && apt-get install -y jq unzip
 COPY ./src/python/fetch-python.sh .
 RUN set -xe \
   && mkdir -p /contrast \

--- a/src/python/fetch-python.sh
+++ b/src/python/fetch-python.sh
@@ -14,8 +14,8 @@ fi
 VERSION=${1:-"latest"}
 if [ "$VERSION" == "latest" ]; then
     VERSION=$(
-        python3 -m pip index versions "contrast-agent" --only-binary :all: \
-        | sed -n 's/.*contrast-agent (\(.*\)).*/\1/p'
+        python3 -m pip index versions --json "contrast-agent" --only-binary :all: \
+        | jq .latest
     )
 fi
 


### PR DESCRIPTION
pip 25.1 includes a [new --json flag](https://pip.pypa.io/en/stable/news/#:~:text=Add%20a%20structured%20%2D%2Djson%20output%20to%20pip%20index%20versions) for structured output, which should be stable for automated use like fetch-python.sh. This PR switches to using this output. I