### PR TITLE
AO-62 Add curl retry for NuGet pulls

### DIFF
--- a/src/dotnet-core/Dockerfile
+++ b/src/dotnet-core/Dockerfile
@@ -10,7 +10,7 @@ RUN set -xe \
 ARG VERSION=4.2.8
 
 RUN set -xe \
-  && curl --location https://www.nuget.org/api/v2/package/Contrast.SensorsNetCore/${VERSION} --output /tmp/contrast.zip \
+  && curl --retry 3 --retry-all-errors --location https://www.nuget.org/api/v2/package/Contrast.SensorsNetCore/${VERSION} --output /tmp/contrast.zip \
   && unzip /tmp/contrast.zip -d /tmp/contrast \
   && rsync -aP /tmp/contrast/contentFiles/any/netstandard2.0/contrast/* /contrast/ \
   && chmod +x /contrast/diagnostics/linux-x64/contrast-dotnet-diagnostics \

--- a/src/dotnet-framework/Dockerfile
+++ b/src/dotnet-framework/Dockerfile
@@ -10,7 +10,7 @@ RUN set -xe \
 ARG VERSION=50.0.18
 
 RUN set -xe \
-  && curl --location https://www.nuget.org/api/v2/package/Contrast.NET.Azure.AppService/${VERSION} --output /tmp/contrast.zip \
+  && curl --retry 3 --retry-all-errors --location https://www.nuget.org/api/v2/package/Contrast.NET.Azure.AppService/${VERSION} --output /tmp/contrast.zip \
   && unzip /tmp/contrast.zip -d /tmp/contrast \
   && rsync -aP /tmp/contrast/content/contrastsecurity/* /contrast/ \
   && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json


### PR DESCRIPTION
NuGet can take a bit of time from pushing up the package to when it is available for download. This adds curl retries to help reduce the docker build step from failing on new releases.