### PR TITLE
CFA-229 Flex Agent Parent Directory Configuration

### DIFF
--- a/src/flex/Dockerfile
+++ b/src/flex/Dockerfile
@@ -30,7 +30,7 @@ COPY ./src/shared/entrypoint.sh /entrypoint.sh
 COPY --from=builder /contrast /contrast
 RUN mkdir -p /contrast/injector \
     && cp /contrast/service/x86_64/agent_injector.so /contrast/injector
-ARG VERSION=0.6.0
+ARG VERSION=0.8.0
 ENV CONTRAST_MOUNT_PATH=/contrast-init \
   CONTRAST_VERSION=${VERSION} \
   CONTRAST_AGENT_TYPE=flex
@@ -45,7 +45,7 @@ COPY ./src/shared/entrypoint.sh /entrypoint.sh
 COPY --from=builder /contrast /contrast
 RUN mkdir -p /contrast/injector \
     && cp /contrast/service/aarch64/agent_injector.so /contrast/injector
-ARG VERSION=0.6.0
+ARG VERSION=0.8.0
 ENV CONTRAST_MOUNT_PATH=/contrast-init \
   CONTRAST_VERSION=${VERSION} \
   CONTRAST_AGENT_TYPE=flex

--- a/src/flex/Dockerfile
+++ b/src/flex/Dockerfile
@@ -7,7 +7,7 @@ RUN set -xe \
   && apt-get update \
   && apt-get install -y curl
 
-ARG VERSION=0.6.0
+ARG VERSION=0.8.0
 
 # Download the flex-agent package, untar
 RUN set -xe \

--- a/src/flex/Dockerfile
+++ b/src/flex/Dockerfile
@@ -19,8 +19,8 @@ RUN set -xe \
 # Create user (required for the agents command to work), generate comms files, enable auto-attach
 RUN set -xe \
   && /contrast/service/x86_64/contrast-flex-service install-user \
-  && /contrast/service/x86_64/contrast-flex-service --comms-dir "/contrast/comms" --agents-dir "/contrast/agents" agents \
-  && /contrast/service/x86_64/contrast-flex-service --comms-dir "/contrast/comms" --agents-dir "/contrast/agents" auto-attach set true
+  && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" agents \
+  && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" auto-attach set true
 
 FROM --platform=linux/amd64 busybox:stable AS final-amd64
 RUN set -xe \

--- a/src/flex/manifest.json
+++ b/src/flex/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.8.0",
   "imageNameSuffix": "flex",
   "dockerFile": "src/flex/Dockerfile",
   "context": ".",
@@ -9,12 +9,12 @@
     "expects": [
       "image-manifest.json",
       "injector/agent_injector.so",
-      "comms/flex_agent.auto_attach",
-      "comms/dotnet-core-arm64-default",
-      "comms/dotnet-core-x64-default",
-      "comms/java-default",
-      "comms/node-default",
-      "comms/python-default"
+      "flex-comms/flex_agent.auto_attach",
+      "flex-comms/dotnet-core-arm64-default",
+      "flex-comms/dotnet-core-x64-default",
+      "flex-comms/java-default",
+      "flex-comms/node-default",
+      "flex-comms/python-default"
     ]
   }
 }


### PR DESCRIPTION
:sparkles: update service flags for parent directory style

With the 0.8.0 version of the Flex Agent and [CFA-222](https://contrast.atlassian.net/browse/CFA-222), the Flex Agent now expects `--comms-dir` and `--agents-dir` to be `--comms-parent-dir` and `--agents-parent-dir` with values pointing to the directories that house the `flex-comms` and `flex-agents` directory respectively. This was done so that the Flex Agent has a lower level directory to create and control in case users specify directories like `/usr/bin`, which we don't want to modify and take ownership of.

[CFA-222]: https://contrast.atlassian.net/browse/CFA-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ