### PR TITLE
[OOB] Upgrades 'dotnet-framework' to '51.2.5'

### DIFF
--- a/src/dotnet-framework/manifest.json
+++ b/src/dotnet-framework/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "51.2.4",
+  "version": "51.2.5",
   "imageNameSuffix": "dotnet-framework",
   "dockerFile": "src/dotnet-framework/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet-framework`
Version: `51.2.4` -> `51.2.5`