### PR TITLE
[OOB] Upgrades 'python' to '10.13.1'

### DIFF
--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.12.0",
+  "version": "10.13.1",
   "imageNameSuffix": "python",
   "dockerFile": "src/python/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `python`
Version: `10.12.0` -> `10.13.1`