### PR TITLE
[OOB] Upgrades 'flex' to '1.3.0'

### DIFF
--- a/src/flex/manifest.json
+++ b/src/flex/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.2",
+  "version": "1.3.0",
   "imageNameSuffix": "flex",
   "dockerFile": "src/flex/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `flex`
Version: `1.2.2` -> `1.3.0`