### PR TITLE
CFA-283 - Update PHP agent ini paths in Dockerfile

### DIFF
--- a/src/flex/Dockerfile
+++ b/src/flex/Dockerfile
@@ -22,6 +22,9 @@ RUN set -xe \
   && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" agents \
   && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" auto-attach set true
 
+# Adjust the absolute path provided in PHP agent ini files
+RUN find /usr/bin/contrast-flex-agent/flex-agents/php/*/*/contrast.ini -type f -exec sed -i 's|/usr/bin/contrast-flex-agent/|/contrast/|g' {} \;
+
 FROM --platform=linux/amd64 busybox:stable AS final-amd64
 RUN set -xe \
   && addgroup -g 1001 custom-group \

--- a/src/flex/Dockerfile
+++ b/src/flex/Dockerfile
@@ -22,7 +22,7 @@ RUN set -xe \
   && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" agents \
   && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" auto-attach set true
 
-# Adjust the absolute path provided in PHP agent ini files# Fix the path for the php agent, '-exec echo "{}" \;' + 'grep .' gives a non-zero exit code if no files were found
+# Fix the path for the php agent, '-exec echo "{}" \;' + 'grep .' gives a non-zero exit code if no files were found
 RUN set -xe \
   && find /contrast/flex-agents/php/ -name contrast.ini -type f -exec echo "{}" \; -exec sed -i 's|/usr/bin/contrast-flex-agent/|${CONTRAST_MOUNT_PATH}/|g' {} \; | grep .
 

--- a/src/flex/Dockerfile
+++ b/src/flex/Dockerfile
@@ -22,8 +22,9 @@ RUN set -xe \
   && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" agents \
   && /contrast/service/x86_64/contrast-flex-service --comms-parent-dir "/contrast" --agents-parent-dir "/contrast" auto-attach set true
 
-# Adjust the absolute path provided in PHP agent ini files
-RUN find /usr/bin/contrast-flex-agent/flex-agents/php/*/*/contrast.ini -type f -exec sed -i 's|/usr/bin/contrast-flex-agent/|/contrast/|g' {} \;
+# Adjust the absolute path provided in PHP agent ini files# Fix the path for the php agent, '-exec echo "{}" \;' + 'grep .' gives a non-zero exit code if no files were found
+RUN set -xe \
+  && find /contrast/flex-agents/php/ -name contrast.ini -type f -exec echo "{}" \; -exec sed -i 's|/usr/bin/contrast-flex-agent/|${CONTRAST_MOUNT_PATH}/|g' {} \; | grep .
 
 FROM --platform=linux/amd64 busybox:stable AS final-amd64
 RUN set -xe \
@@ -31,8 +32,9 @@ RUN set -xe \
   && adduser -u 1001 -G custom-group -D -H custom-user
 COPY ./src/shared/entrypoint.sh /entrypoint.sh
 COPY --from=builder /contrast /contrast
-RUN mkdir -p /contrast/injector \
-    && cp /contrast/service/x86_64/agent_injector.so /contrast/injector
+RUN set -xe \
+  && mkdir -p /contrast/injector \
+  && cp /contrast/service/x86_64/agent_injector.so /contrast/injector
 ARG VERSION=0.8.0
 ENV CONTRAST_MOUNT_PATH=/contrast-init \
   CONTRAST_VERSION=${VERSION} \
@@ -46,8 +48,9 @@ RUN set -xe \
   && adduser -u 1001 -G custom-group -D -H custom-user
 COPY ./src/shared/entrypoint.sh /entrypoint.sh
 COPY --from=builder /contrast /contrast
-RUN mkdir -p /contrast/injector \
-    && cp /contrast/service/aarch64/agent_injector.so /contrast/injector
+RUN set -xe \
+  && mkdir -p /contrast/injector \
+  && cp /contrast/service/aarch64/agent_injector.so /contrast/injector
 ARG VERSION=0.8.0
 ENV CONTRAST_MOUNT_PATH=/contrast-init \
   CONTRAST_VERSION=${VERSION} \


### PR DESCRIPTION
- find all versions of the PHP `contrast.ini` file and update the path to use the environment `CONTRAST_MOUNT_PATH`
- the command should allow for any PHP agent version number
- the command should allow for any architecture
- if no files are changed, the build should fail


contrast.ini (before)
```
extension=/usr/bin/contrast-flex-agent/flex-agents/php/1.44.0/amd64/contrast.so
```

contrast.ini (after)
```
extension=${CONTRAST_MOUNT_PATH}/flex-agents/php/1.44.0/amd64/contrast.so
```