### PR TITLE
CFA-504: verify Flex UUID is set

### DIFF
--- a/src/flex/manifest.json
+++ b/src/flex/manifest.json
@@ -15,6 +15,8 @@
       "flex-comms/dotnet-core-x64-default",
       "flex-comms/java-default",
       "flex-comms/node-default",
+      "flex-comms/php-amd64-default",
+      "flex-comms/php-arm64-default",
       "flex-comms/python-default"
     ]
   }

--- a/src/flex/manifest.json
+++ b/src/flex/manifest.json
@@ -9,6 +9,7 @@
     "expects": [
       "image-manifest.json",
       "injector/agent_injector.so",
+      "flex-comms/contrast_flex_id",
       "flex-comms/flex_agent.auto_attach",
       "flex-comms/dotnet-core-arm64-default",
       "flex-comms/dotnet-core-x64-default",


### PR DESCRIPTION
:white_check_mark: verify ID file exists for injector to read

https://github.com/Contrast-Security-Inc/contrast-flex-agent/pull/440 should handle this -- calling the `agents` or `auto-attach` command would initialize the Comms Writer and generate the comms dir and UUID marker. I'll move this to `Ready for Review` after the release of the Flex Agent with this change. 