### PR TITLE
[OOB] Upgrades 'nodejs' to '5.58.0'

### DIFF
--- a/src/nodejs/manifest.json
+++ b/src/nodejs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.57.0",
+  "version": "5.58.0",
   "imageNameSuffix": "nodejs",
   "dockerFile": "src/nodejs/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by jcolekaplan.

Agent: `nodejs`
Version: `5.57.0` -> `5.58.0`