### PR TITLE
Use @contrast/agent-bundle for agent-nodejs

### DIFF
--- a/src/nodejs/Dockerfile
+++ b/src/nodejs/Dockerfile
@@ -6,11 +6,12 @@ FROM node:lts-slim AS builder
 ARG VERSION
 RUN test -n "$VERSION" || (echo "VERSION arg not set, pass --build-arg 'VERSION=<version>' to docker build" && false)
 
+# Install the @contrast/agent-bundle but move the node_modules up a directory to maintain the old folder structure
 RUN set -xe \
+  && mkdir -p /tmp/contrast \
+  && npm install --prefix /tmp/contrast @contrast/agent-bundle@${VERSION} \
   && mkdir -p /contrast \
-  && npm install --prefix /contrast @contrast/agent@${VERSION} \
-  && npm install --prefix /contrast @swc/core --libc=glibc \
-  && npm install --prefix /contrast @swc/core --libc=musl \
+  && cp --force --recursive /tmp/contrast/node_modules/@contrast/agent-bundle/node_modules /contrast/ \
   && echo "{ \"version\": \"${VERSION}\" }" > /contrast/image-manifest.json
 
 FROM busybox:stable AS final


### PR DESCRIPTION
Use @contrast/agent-bundle instead because it includes @swc/core for the platforms that are supported. 

We move the node_modules up a directory so it maintains the existing folder structure the NodeJsAgentPatchers are expecting for setting NODE_OPTIONS. This is to avoid a breaking change that requires customers to upgrade the agent-operator.