### PR TITLE
[OOB] Upgrades 'dotnet-core' to '60.1.0'

### DIFF
--- a/src/dotnet-core/manifest.json
+++ b/src/dotnet-core/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "60.0.1",
+  "version": "60.1.0",
   "imageNameSuffix": "dotnet-core",
   "dockerFile": "src/dotnet/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet-core`
Version: `60.0.1` -> `60.1.0`