### PR TITLE
Bump dotnet version

### DIFF
--- a/src/dotnet/manifest.json
+++ b/src/dotnet/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "60.0.1",
+  "version": "60.1.0",
   "imageNameSuffix": "dotnet",
   "dockerFile": "src/dotnet/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Release pipeline didnt call the oob-update for the combined dotnet agent type.