### PR TITLE
[OOB] Upgrades 'flex' to '2.2.0'

### DIFF
--- a/src/flex/manifest.json
+++ b/src/flex/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.2.0",
   "imageNameSuffix": "flex",
   "dockerFile": "src/flex/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `flex`
Version: `2.1.0` -> `2.2.0`