### PR TITLE
[OOB] Upgrades 'python' to '11.7.0'

### DIFF
--- a/src/python/manifest.json
+++ b/src/python/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.6.0",
+  "version": "11.7.0",
   "imageNameSuffix": "python",
   "dockerFile": "src/python/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `python`
Version: `11.6.0` -> `11.7.0`