### PR TITLE
[OOB] Upgrades 'dotnet' to '60.1.2'

### DIFF
--- a/src/dotnet-core/manifest.json
+++ b/src/dotnet-core/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "60.1.1",
+  "version": "60.1.2",
   "imageNameSuffix": "dotnet-core",
   "dockerFile": "src/dotnet/Dockerfile",
   "context": ".",

--- a/src/dotnet-framework/manifest.json
+++ b/src/dotnet-framework/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "60.1.1",
+  "version": "60.1.2",
   "imageNameSuffix": "dotnet-framework",
   "dockerFile": "src/dotnet-framework/Dockerfile",
   "context": ".",

--- a/src/dotnet/manifest.json
+++ b/src/dotnet/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "60.1.1",
+  "version": "60.1.2",
   "imageNameSuffix": "dotnet",
   "dockerFile": "src/dotnet/Dockerfile",
   "context": ".",


### PR DESCRIPTION
Automated OOB update requested by SvcGitHubPATagentoperatorimages.

Agent: `dotnet`
Version: `60.1.1` -> `60.1.2`